### PR TITLE
feat(docker): Add Dockerfile with graphicsmagick for PDF processing

### DIFF
--- a/DOCKERFILE
+++ b/DOCKERFILE
@@ -1,0 +1,9 @@
+FROM node:20-slim
+WORKDIR /app
+RUN apt-get update && \
+    apt-get install -y graphicsmagick && \
+    rm -rf /var/lib/apt/lists/* # Clean up apt cache to keep image small
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+CMD ["node", "./src/bot.js"]


### PR DESCRIPTION
This Dockerfile uses node:20-slim and installs GraphicsMagick for PDF image conversion support. Dependencies are installed in production mode, and the bot starts with node src/bot.js.