### PR TITLE
Potential fix for code scanning alert no. 7: Clear-text logging of sensitive information

### DIFF
--- a/src/utils/debug.js
+++ b/src/utils/debug.js
@@ -295,8 +295,8 @@ node your_script.js -d --debug-no-sanitize          # Disable sanitization (NOT 
 
 		this._outputDebug(debugMsg);
 
-		// Apply security measures to data before logging
-		if (data !== null && (level === 'verbose' || level === 'trace' || this.level !== 'info')) {
+		// Always sanitize and limit data before logging, regardless of log level
+		if (data !== null) {
 			const sanitizedData = this._sanitizeData(data);
 			const limitedData = this._limitDataLength(sanitizedData);
 			this._outputDebug(`[DATA]`, limitedData);
@@ -344,6 +344,7 @@ node your_script.js -d --debug-no-sanitize          # Disable sanitization (NOT 
 		if (this.debugStream) this.debugStream.write(sanitizedMessage + '\n');
 		}
 		if (data !== null) {
+		// Data should already be sanitized and limited before being passed here
 		const formattedData = JSON.stringify(data, null, 2);
 		console.log(formattedData);
 		if (this.debugStream) this.debugStream.write(formattedData + '\n');


### PR DESCRIPTION
Potential fix for [https://github.com/FSU-Pulchowk/discord-bot/security/code-scanning/7](https://github.com/FSU-Pulchowk/discord-bot/security/code-scanning/7)

To fix the problem, we need to ensure that any data passed to the logger is always sanitized before being logged, regardless of the log level. This means applying the `_sanitizeData` method to all data before it is output, not just for certain log levels. Specifically, in the `log` method, we should sanitize and limit the data before passing it to `_outputDebug`, regardless of the log level. Additionally, in the `_outputDebug` method, we should avoid directly logging unsanitized data. The changes should be made in `src/utils/debug.js`, in the `log` and `_outputDebug` methods. No new imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
