### PR TITLE
Potential fix for code scanning alert no. 7: Clear-text logging of sensitive information

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -1677,7 +1677,13 @@ class PulchowkBot {
         try {
             announcementChannel = await this.client.channels.fetch(BIRTHDAY_ANNOUNCEMENT_CHANNEL_ID);
             if (!announcementChannel) {
-                this.debugConfig.log('Birthday announcement channel not found', 'scheduler', { channelId: BIRTHDAY_ANNOUNCEMENT_CHANNEL_ID }, null, 'error');
+                this.debugConfig.log(
+                    'Birthday announcement channel not found',
+                    'scheduler',
+                    { channelId: BIRTHDAY_ANNOUNCEMENT_CHANNEL_ID ? '[REDACTED]' : '(not set)' },
+                    null,
+                    'error'
+                );
                 return;
             }
         } catch (error) {


### PR DESCRIPTION
Potential fix for [https://github.com/FSU-Pulchowk/discord-bot/security/code-scanning/7](https://github.com/FSU-Pulchowk/discord-bot/security/code-scanning/7)

To fix the problem, instead of passing environment variables (such as `BIRTHDAY_ANNOUNCEMENT_CHANNEL_ID`) or any potentially sensitive data directly to log functions, the code should ensure that only non-sensitive information is logged. The best way to prevent leaking sensitive data is to remove or redact such data before logging. Specifically, in src/bot.js, wherever an environment-derived value is logged, its actual value should be masked/redacted or omitted. As for keys where a reference is useful (such as a channel ID), only the existence, shape, or an obfuscated value (e.g., hash or partial) should be logged. 

For this case, the log call on line 1680 in src/bot.js is:
```js
this.debugConfig.log('Birthday announcement channel not found', 'scheduler', { channelId: BIRTHDAY_ANNOUNCEMENT_CHANNEL_ID }, null, 'error');
```
Instead of logging the actual channel ID, log only that the value is present (or missing), or, if really needed, a redacted form (first few/last few characters).

No library changes are needed; change only the argument to log in src/bot.js.  
No change is required in src/utils/debug.js (the log method attempts sanitization, but as shown above, code that depends solely on this is not robust enough).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
